### PR TITLE
Removed priority argument

### DIFF
--- a/default-image-for-image-field.php
+++ b/default-image-for-image-field.php
@@ -4,7 +4,7 @@
   // let's you select a defualt image
   // this is simply taking advantage of a field setting that already exists
   
-	add_action('acf/render_field_settings/type=image', 'add_default_value_to_image_field', 20);
+	add_action('acf/render_field_settings/type=image', 'add_default_value_to_image_field');
 	function add_default_value_to_image_field($field) {
 		acf_render_field_setting( $field, array(
 			'label'			=> 'Default Image',


### PR DESCRIPTION
Having the priority argument causes rendering issues on existing field groups (e.g if you have a section already created and then add this function, it will create strange output in the admin when managing that section). Removing this worked as intended to create the default image :)