### PR TITLE
Replace first parameter on get_ancestors function

### DIFF
--- a/page-nth-level-location-rule.php
+++ b/page-nth-level-location-rule.php
@@ -52,7 +52,7 @@
 		if (!$page_parent) {
 			$page_level = 1;
 		} else {
-			$ancestors = get_ancestors($options['page_parent'], $post_type);
+			$ancestors = get_ancestors($page_parent, $post_type);
 			$page_level = count($ancestors) + 2;
 		}
 		$operator = $rule['operator'];


### PR DESCRIPTION
In the conditional that start at line 46 the variable $page_parent are modified within the right values but you probably forgot to pass it at the line 55 on the get_ancestors function.